### PR TITLE
Pin nginx:alpine to nginx:1.29-alpine for reproducible builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM nginx:alpine
+FROM nginx:1.29-alpine
 COPY nginx.conf /etc/nginx/conf.d/default.conf
 WORKDIR /usr/share/nginx/html
 COPY . .


### PR DESCRIPTION
## Problem

`FROM nginx:alpine` (without a version tag) is a non-reproducible base image. Two builds at different times may pull different nginx versions, which can silently introduce CVEs or breaking changes.

## Fix

Pin to `nginx:1.29-alpine` (current stable), matching the pattern already used in `locative.garden`.

## Audit notes

| Area | Finding | Action |
|------|---------|--------|
| Dockerfile | `FROM nginx:alpine` unpinned | **Fixed (this PR)** |
| Dockerfile | `RUN ls -alh` is a debug line that leaks directory contents into build logs | Low severity — not fixed here to keep this PR minimal; consider removing in a follow-up |
| Static site | Pure HTML/CSS/JS, no dynamic content | No action needed |
