### PR TITLE
chore: Add OCI annotation labels for GHCR

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,8 @@
 FROM nginx:1.29-alpine
+
+LABEL org.opencontainers.image.source=https://github.com/icco/resume
+LABEL org.opencontainers.image.description="A markdown port of my resume"
+LABEL org.opencontainers.image.licenses=AGPL-3.0
 COPY nginx.conf /etc/nginx/conf.d/default.conf
 WORKDIR /usr/share/nginx/html
 COPY . .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM nginx:1.29-alpine
 
 LABEL org.opencontainers.image.source=https://github.com/icco/resume
-LABEL org.opencontainers.image.description="A markdown port of my resume"
+LABEL org.opencontainers.image.description="Nat Welch's resume; a static HTML/CSS site served at resume.natwelch.com."
 LABEL org.opencontainers.image.licenses=AGPL-3.0
 COPY nginx.conf /etc/nginx/conf.d/default.conf
 WORKDIR /usr/share/nginx/html


### PR DESCRIPTION
Adds the GitHub-recommended OCI annotation labels to the Dockerfile so that
the GHCR package page links back to this repo and shows description/license.

See: https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry#labelling-container-images

Labels added to the final image stage:
- `org.opencontainers.image.source`
- `org.opencontainers.image.description`
- `org.opencontainers.image.licenses` (where a recognizable LICENSE exists)